### PR TITLE
Allow using taskFor at assignment

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3,7 +3,7 @@ import { assert } from '@ember/debug';
 export function taskFor(task) {
   assert(
     `${task} does not appear to be a task!`,
-    task && typeof task.perform === 'function'
+    task && (typeof task === 'function' || typeof task.perform === 'function')
   );
 
   return task;

--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -199,4 +199,86 @@ module('Integration | ember-concurrency-ts', function(hooks) {
     assert.dom('#value').hasText('Done!');
     assert.dom('#resolved').hasText('Wow!');
   });
+
+  test('it works at assignment', async function(assert) {
+    let { promise, resolve } = defer<string>();
+
+    class MyComponent extends Component {
+      resolved: string | null = null;
+      lastValue: string | null = null;
+
+      @task myTask = taskFor(function*(this: MyComponent, arg: string): TaskGenerator<string> {
+        set(this, 'resolved', yield promise);
+        return arg;
+      });
+
+      _() {
+        expectTypeOf(this.myTask).toMatchTypeOf<Task<unknown, unknown[]>>();
+      }
+
+      @computed('myTask.performCount')
+      get isWaiting(): boolean {
+        expectTypeOf(this.myTask.performCount).toEqualTypeOf<number>();
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning(): boolean {
+        expectTypeOf(this.myTask.isRunning).toEqualTypeOf<boolean>();
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value(): string | null | undefined {
+        expectTypeOf(this.myTask.last).toEqualTypeOf<TaskInstance<string> | null>();
+        expectTypeOf(this.myTask.last!.value).toEqualTypeOf<string | null>();
+        return this.myTask.last?.value;
+      }
+
+      @action performMyTask(arg: string) {
+        this.myTask.perform(arg).then(value => {
+          expectTypeOf(value).toEqualTypeOf<string>();
+          set(this, 'lastValue', value);
+        });
+      }
+    }
+
+    this.owner.register('component:test', MyComponent);
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (fn this.performMyTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+      {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
 });

--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -281,4 +281,94 @@ module('Integration | ember-concurrency-ts', function(hooks) {
     assert.dom('#value').hasText('Done!');
     assert.dom('#resolved').hasText('Wow!');
   });
+
+  test('it works for encapsulated tasks at assignment', async function(assert) {
+    let { promise, resolve } = defer<string>();
+
+    class MyComponent extends Component {
+      lastValue: string | null = null;
+
+      @task myTask = taskFor({
+        resolved: '',
+        *perform(arg: string): TaskGenerator<string> {
+          set(this, 'resolved', yield promise);
+          return arg;
+        }
+      });
+
+      _() {
+        expectTypeOf(this.myTask).toMatchTypeOf<EncapsulatedTask<string, [string], { resolved: string }>>();
+      }
+
+      @computed('myTask.performCount')
+      get isWaiting(): boolean {
+        expectTypeOf(this.myTask.performCount).toEqualTypeOf<number>();
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning(): boolean {
+        expectTypeOf(this.myTask.isRunning).toEqualTypeOf<boolean>();
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value(): string | null | undefined {
+        expectTypeOf(this.myTask.last).toEqualTypeOf<EncapsulatedTaskInstance<string, { resolved: string }> | null>();
+        expectTypeOf(this.myTask.last!.value).toEqualTypeOf<string | null>();
+        return this.myTask.last?.value;
+      }
+
+      @computed('myTask.resolved')
+      get resolved(): string | undefined {
+        expectTypeOf(this.myTask.last?.resolved).toEqualTypeOf<string>();
+        return this.myTask.last?.resolved;
+      }
+
+      @action performMyTask(arg: string) {
+        this.myTask.perform(arg).then(value => {
+          expectTypeOf(value).toEqualTypeOf<string>();
+          set(this, 'lastValue', value);
+        });
+      }
+    }
+
+    this.owner.register('component:test', MyComponent);
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (fn this.performMyTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+      {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
 });

--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -208,6 +208,9 @@ module('Integration | ember-concurrency-ts', function(hooks) {
       lastValue: string | null = null;
 
       @task myTask = taskFor(function*(this: MyComponent, arg: string): TaskGenerator<string> {
+        expectTypeOf(this).not.toBeAny();
+        expectTypeOf(this.resolved).not.toBeAny();
+        expectTypeOf(this.resolved).toMatchTypeOf<string | null>();
         set(this, 'resolved', yield promise);
         return arg;
       });
@@ -291,6 +294,9 @@ module('Integration | ember-concurrency-ts', function(hooks) {
       @task myTask = taskFor({
         resolved: '',
         *perform(arg: string): TaskGenerator<string> {
+          expectTypeOf(this).not.toBeAny();
+          expectTypeOf(this.resolved).not.toBeAny();
+          expectTypeOf(this.resolved).toBeString();
           set(this, 'resolved', yield promise);
           return arg;
         }


### PR DESCRIPTION
This adjusts the assertion on the argument passed to `taskFor` such that it can be used at assignment, e.g.
```ts
@task
myTask = taskFor(function*() {
  yield 1;
  return 2;
});