### PR TITLE
add a test for usage with encapsulated tasks

### DIFF
--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -113,6 +113,9 @@ module('Integration | ember-concurrency-ts', function(hooks) {
       @task myTask = {
         resolved: '',
         *perform(arg: string): TaskGenerator<string> {
+          expectTypeOf(this).not.toBeAny();
+          expectTypeOf(this.resolved).not.toBeAny();
+          expectTypeOf(this.resolved).toBeString();
           set(this, 'resolved', yield promise);
           return arg;
         }

--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -4,7 +4,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { action, computed, set } from '@ember/object';
 import { click, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { Task, TaskGenerator, TaskInstance } from 'ember-concurrency';
+import {
+  Task,
+  TaskGenerator,
+  TaskInstance,
+  EncapsulatedTask,
+  EncapsulatedTaskDescriptor,
+  EncapsulatedTaskInstance,
+} from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor, perform } from 'ember-concurrency-ts';
 import { expectTypeOf } from 'expect-type';
@@ -48,6 +55,97 @@ module('Integration | ember-concurrency-ts', function(hooks) {
         expectTypeOf(taskFor(this.myTask).last).toEqualTypeOf<TaskInstance<string> | null>();
         expectTypeOf(taskFor(this.myTask).last!.value).toEqualTypeOf<string | null>();
         return taskFor(this.myTask).last?.value;
+      }
+
+      @action performMyTask(arg: string) {
+        perform(this.myTask, arg).then(value => {
+          expectTypeOf(value).toEqualTypeOf<string>();
+          set(this, 'lastValue', value);
+        });
+      }
+    }
+
+    this.owner.register('component:test', MyComponent);
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (fn this.performMyTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+      {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
+
+  test('it works for encapsulated tasks', async function(assert) {
+    let { promise, resolve } = defer<string>();
+
+    class MyComponent extends Component {
+      lastValue: string | null = null;
+
+      @task myTask = {
+        resolved: '',
+        *perform(arg: string): TaskGenerator<string> {
+          set(this, 'resolved', yield promise);
+          return arg;
+        }
+      }
+
+      _() {
+        expectTypeOf(this.myTask).toMatchTypeOf<EncapsulatedTaskDescriptor<string, [string]>>();
+        expectTypeOf(taskFor(this.myTask)).toEqualTypeOf<EncapsulatedTask<string, [string], { resolved: string }>>();
+      }
+
+      @computed('myTask.performCount')
+      get isWaiting(): boolean {
+        expectTypeOf(taskFor(this.myTask).performCount).toEqualTypeOf<number>();
+        return taskFor(this.myTask).performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning(): boolean {
+        expectTypeOf(taskFor(this.myTask).isRunning).toEqualTypeOf<boolean>();
+        return taskFor(this.myTask).isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value(): string | null | undefined {
+        expectTypeOf(taskFor(this.myTask).last).toEqualTypeOf<EncapsulatedTaskInstance<string, { resolved: string }> | null>();
+        expectTypeOf(taskFor(this.myTask).last!.value).toEqualTypeOf<string | null>();
+        return taskFor(this.myTask).last?.value;
+      }
+
+      @computed('myTask.resolved')
+      get resolved(): string | undefined {
+        expectTypeOf(taskFor(this.myTask).last?.resolved).toEqualTypeOf<string>();
+        return taskFor(this.myTask).last?.resolved;
       }
 
       @action performMyTask(arg: string) {

--- a/tests/integration/ember-concurrency-ts-test.ts
+++ b/tests/integration/ember-concurrency-ts-test.ts
@@ -10,13 +10,15 @@ import {
   TaskInstance,
   EncapsulatedTask,
   EncapsulatedTaskDescriptor,
-  EncapsulatedTaskInstance,
+  EncapsulatedTaskState,
 } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor, perform } from 'ember-concurrency-ts';
 import { expectTypeOf } from 'expect-type';
 import Component from '@glimmer/component';
 import { defer } from 'dummy/tests/utils';
+
+type EncapsulatedTaskInstance<T, State extends object> = TaskInstance<T> & EncapsulatedTaskState<State>;
 
 module('Integration | ember-concurrency-ts', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
This adds a test that uses `taskFor` and `perform` with an encapsulated task.