### PR TITLE
Add ember-concurrency@^2.0.0-rc.1 as a supported peer dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
-  pull_request: {}
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars": "^4.3.1"
   },
   "peerDependencies": {
-    "ember-concurrency": "^1.2.1",
+    "ember-concurrency": "^1.2.1 || ^2.0.0-rc.1",
     "ember-concurrency-decorators": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It works fine with 2.0.0-rc.1 (at least via the ember-concurrency 2.0.0-rc.1 test suite), but this should get rid of the warning of "unfulfilled peer dependencies" with that version.