### PR TITLE
fix: type errors that occur when using ec >2.3

### DIFF
--- a/async.d.ts
+++ b/async.d.ts
@@ -12,12 +12,11 @@ import {
 import { taskFor, perform, Descriptor } from 'ember-concurrency-ts';
 
 type AsyncTaskFunction = GenericAsyncTaskFunction<any, any[]>;
-type AsyncDescriptor = GenericAsyncDescriptor<any, any[]>;
 
 declare module 'ember-concurrency-ts' {
-  function taskFor<T extends AsyncTaskFunction>(task: T): AsyncTaskFor<T>;
+  function taskFor<HostObject, T extends AsyncTaskFunction>(task: T): AsyncTaskFor<HostObject, T>;
   function taskFor<T extends AsyncDescriptor>(task: T): AsyncTaskForDescriptor<T>;
 
-  function perform<T extends AsyncTaskFunction>(task: T, ...args: Args<T>): AsyncInstanceFor<T>;
+  function perform<HostObject, T extends AsyncTaskFunction>(task: T, ...args: Args<T>): AsyncInstanceFor<HostObject, T>;
   function perform<T extends AsyncDescriptor>(task: T, ...args: DescriptorArgs<T>): AsyncInstanceForDescriptor<T>;
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-typescript": "^3.1.4",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
-    "ember-concurrency": "^2.0.3",
+    "ember-concurrency": "^2.3.0",
     "ember-concurrency-async": "^1.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",


### PR DESCRIPTION
With ember-concurrency 2.3 we no longer require these packages _if_ we update all our tasks. If we want to use both syntaxes (with a large code base for example) then the exported types from this package and ember-concurrency-async create issues with types (see related PR here https://github.com/chancancode/ember-concurrency-async/pull/46).

This change proposes to publish a version of ember-concurrency-ts and ember-concurrency-async for use with ember-concurrency 2.3+ to help bridge the gap.

This would be a breaking change and only for users who have ember-concurrency 2.3+.